### PR TITLE
nids-extract improvements

### DIFF
--- a/nids-extract/src/main.c
+++ b/nids-extract/src/main.c
@@ -31,10 +31,31 @@ void getExports(SceModuleInfo *mod_info, uint8_t *segment0, uint32_t vaddr, uint
 				printf("      %s:\n", lib_name);
 				printf("        kernel: %s\n", is_kernel ? "true" : "false");
 				printf("        nid: 0x%08X\n", exp_table->module_nid);
-				printf("        functions:\n");
-				for (int j = 0; j < exp_table->num_functions; j++) {
-					uint32_t nid = nid_table[j];
-					printf("          %s_%08X: 0x%08X\n", lib_name, nid, nid);
+
+				int j = 0;
+
+				if (exp_table->num_functions > 0) {
+					printf("        functions:\n");
+					for (int k = 0; k < exp_table->num_functions; k++) {
+						uint32_t nid = nid_table[j++];
+						printf("          %s_%08X: 0x%08X\n", lib_name, nid, nid);
+					}
+				}
+
+				if (exp_table->num_vars > 0) {
+					printf("        variables:\n");
+					for (int k = 0; k < exp_table->num_vars; k++) {
+						uint32_t nid = nid_table[j++];
+						printf("          %s_%08X: 0x%08X\n", lib_name, nid, nid);
+					}
+				}
+
+				if (exp_table->num_tls_vars > 0) {
+					printf("        tls-variables:\n");
+					for (int k = 0; k < exp_table->num_tls_vars; k++) {
+						uint32_t nid = nid_table[j++];
+						printf("          %s_%08X: 0x%08X\n", lib_name, nid, nid);
+					}
 				}
 			}
 		}/* else 

--- a/nids-extract/src/main.c
+++ b/nids-extract/src/main.c
@@ -19,8 +19,17 @@ void getExports(SceModuleInfo *mod_info, uint8_t *segment0, uint32_t vaddr, uint
 			char *lib_name = (char *)(segment0 + exp_table->lib_name - vaddr);
 			uint32_t *nid_table = (uint32_t *)(segment0 + exp_table->nid_table - vaddr);	
 			if (exp_table->lib_name) {
+				int is_kernel = 0;
+				int lib_name_len = strlen(lib_name);
+				if (lib_name_len >= 9) {
+					char *suffix = lib_name + lib_name_len - 9;
+					if (0 == strcmp(suffix, "ForDriver") || 0 == strcmp(suffix, "ForKernel")) {
+						is_kernel = 1;
+					}
+				}
+
 				printf("      %s:\n", lib_name);
-				printf("        kernel: %s\n", (exp_table->attribute&0x4000) ? "false" : "true");
+				printf("        kernel: %s\n", is_kernel ? "true" : "false");
 				printf("        nid: 0x%08X\n", exp_table->module_nid);
 				printf("        functions:\n");
 				for (int j = 0; j < exp_table->num_functions; j++) {

--- a/nids-extract/src/self.h
+++ b/nids-extract/src/self.h
@@ -158,8 +158,9 @@ typedef struct {
 	uint16_t lib_version;
 	uint16_t attribute;
 	uint16_t num_functions;
-	uint32_t num_vars;
-	uint32_t num_tls_vars;
+	uint16_t num_vars;
+	uint16_t num_tls_vars;
+	uint32_t unknown;
 	uint32_t module_nid;
 	uint32_t lib_name;
 	uint32_t nid_table;


### PR DESCRIPTION
1. Improve kernel/user library heuristics

    For any user module, the syscall flag will not be set so they are
    wrongly determined to have kernel libraries. All SCE kernel libraries
    have the suffix "ForKernel" or "ForDriver". So we use that to determine
    if a library is kernel or user.

2. Extract variables and tls variables