### PR TITLE
Fixed folder access problem on Linux and Android Termux.

### DIFF
--- a/psp2-kbl-elf-extract/src/main.c
+++ b/psp2-kbl-elf-extract/src/main.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
 		sprintf(output_path, "kbl_elf_out");
 	else
 		sprintf(output_path, "%s", argv[2]);
-	mkdir(output_path, 777);
+	mkdir(output_path, 0777);
 
 	for (unsigned int offset = 0; offset < filesize-8; offset += 1) {
 		void *current_addr = buffer + offset;


### PR DESCRIPTION
 mkdir(folder, 777) should be mkdir(folder, 0777) to apply permissions correctly.